### PR TITLE
Bug fix for reg exp for parsing hashtags fails if the message starts with hash

### DIFF
--- a/lib/chat.js
+++ b/lib/chat.js
@@ -32,7 +32,7 @@ function xssIt(message) {
 
 var createPost = function (user, message, callback) {
 
-  dbAccess.addPost(user, xssIt(message), hashTagParser.getHashTags, function (result) {
+  dbAccess.addPost(user, message, xssIt, hashTagParser.getHashTags, function (result) {
     if (result.success === false) {
       console.log(result.errorMessage);
       callback(result);
@@ -46,7 +46,7 @@ var createPost = function (user, message, callback) {
 module.exports.createPost = createPost;
 
 var replyPost = function (id, user, message, callback) {
-  dbAccess.addReply(id, user, xssIt(message), function (result) {
+  dbAccess.addReply(id, user, message, xssIt, hashTagParser.getHashTags, function (result) {
     if (result.success === false) {
       console.log(result.errorMessage);
       callback(result);

--- a/lib/dbAccess/dbAccess.js
+++ b/lib/dbAccess/dbAccess.js
@@ -39,7 +39,7 @@ module.exports.connectToDb = function (connectionString) {
   }
 };
 
-module.exports.addPost = function (username, message, hashtagParser, callback) {
+module.exports.addPost = function (username, message, xssIt, hashtagParser, callback) {
   if (username === "") {
     callback(createError("Username is required"));
     return;
@@ -52,7 +52,7 @@ module.exports.addPost = function (username, message, hashtagParser, callback) {
 
   var post = new Post();
   post.username = username;
-  post.message = message;
+  post.message = xssIt(message);
   post.time = new Date();
   post.hashtags = hashtagParser(message);
 
@@ -100,7 +100,7 @@ module.exports.getAllPosts = function (pageNumber, callback) {
     });
 };
 
-module.exports.addReply = function (id, username, message, callback) {
+module.exports.addReply = function (id, username, message, xssIt, hashtagParser, callback) {
 
   if (username === "") {
     callback(createError("Username is required"));
@@ -115,8 +115,9 @@ module.exports.addReply = function (id, username, message, callback) {
   var r = new Reply();
   r.parentPostId = id;
   r.username = username;
-  r.message = message;
+  r.message = xssIt(message);
   r.time = new Date();
+  r.hashtags = hashtagParser(message);
 
   Reply.create(r, function (err, reply) {
     if (err) {

--- a/lib/hashtagparser.js
+++ b/lib/hashtagparser.js
@@ -1,5 +1,5 @@
 var hashTagParser = hashTagParser || {};
-var hashTagPattern = /(^|\s)#([åäöÅÄÖ\w]+)/ig;
+var hashTagPattern = /(^|\s|)#([åäöÅÄÖ\w]+)/ig;
 
 exports.pattern = function () {
   return hashTagPattern;

--- a/test/bugs.spec.js
+++ b/test/bugs.spec.js
@@ -1,0 +1,43 @@
+var should = require('should');
+var chat = require('../lib/chat.js');
+var testHelpers = require("./dbAccess/testHelpers.js");
+
+describe('All bugs', function () {
+
+  before(function (done) {
+    testHelpers.connectMongo();
+    done();
+  });
+
+  after(function (done) {
+    testHelpers.deleteAll();
+    done();
+  });
+
+  describe('Bug #14', function () {
+
+    it('A post that starts with a tag should parse the tag', function (done) {
+      var message = '#aptitalk is the best';
+      var user = 'hugo';
+      chat.createPost(user, message, function (post) {
+        post.hashtags.length.should.equal(1);
+        post.hashtags[0].should.equal('aptitalk');
+        done();
+      });
+    });
+
+    it('A reply that starts with a tag should parse the tag', function (done) {
+      var message = '#aptitalk is the best';
+      var user = 'hugo';
+      chat.createPost(user, message, function (post) {
+        chat.replyPost(post._id, user, message, function (reply) {
+          reply.hashtags.length.should.equal(1);
+          post.hashtags[0].should.equal('aptitalk');
+          done();
+        });
+      });
+    });
+
+  });
+
+});

--- a/test/dbAccess/addPost.spec.js
+++ b/test/dbAccess/addPost.spec.js
@@ -5,87 +5,87 @@ var testHelpers = require("./testHelpers.js");
 
 describe("Adding posts", function () {
 
-	before(function (done) {
-		testHelpers.connectMongo();
-		done();
-	});
+  before(function (done) {
+    testHelpers.connectMongo();
+    done();
+  });
 
-	beforeEach(function (done) {
-		testHelpers.deleteAll();
-		done();
-	});
+  beforeEach(function (done) {
+    testHelpers.deleteAll();
+    done();
+  });
 
-	after(function (done) {
-		testHelpers.deleteAll();
-		done();
-	});
+  after(function (done) {
+    testHelpers.deleteAll();
+    done();
+  });
 
-	it("adds a correctly formatted new message", function (done) {
-		dbAccess
-			.addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.getHashTagsFromMessage, function (result) {
-				testHelpers.validateOkResult(result);
-				should.exists(result.data._id);
-				result.data.username.should.be.equal(testHelpers.USERNAME);
-				result.data.message.should.be.equal(testHelpers.MESSAGE);
-				done();
-		});
-	});
-	it("calls my callback function with the error when an error occurs", function (done) {
-		dbAccess.addPost("", "", testHelpers.getHashTagsFromMessage, function (result) {
-			testHelpers.validateErrorResult(result, "");
-			done();
-		});
-	});
-	it("validates the prescense of an user name", function (done) {
-		dbAccess.addPost("", testHelpers.MESSAGE, testHelpers.getHashTagsFromMessage, function (result) {
-			testHelpers.validateErrorResult(result, "Username");
-			done();
-		});
-	});
-	it("validates the prescense of a message", function (done) {
-		dbAccess.addPost(testHelpers.USERNAME, "", testHelpers.getHashTagsFromMessage, function (result) {
-			testHelpers.validateErrorResult(result, "Message");
-			done();
-		});
-	});
-	it("adds the posted date", function (done) {
-		dbAccess.addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.getHashTagsFromMessage, function (result) {
-			testHelpers.validateOkResult(result);
-			should.exists(result.data.time);
-			done();
-		});
-	});
-	it("creates the post with no replies", function (done) {
-		dbAccess.addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.getHashTagsFromMessage, function (result) {
-			testHelpers.validateOkResult(result);
-			result.data.replies.should.be.emtpy;
-			done();
-		});
-	});
-	it("creates an empty hashtag list for no hashtags", function (done) {
-		dbAccess.addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.getHashTagsFromMessage, function (result) {
-			testHelpers.validateOkResult(result);
-			result.data.hashtags.should.be.emtpy;
-			done();
-		});
-	});
-	it("creates an array with 1 hashtag for 1 hashtag in the message", function (done) {
-		dbAccess.addPost(testHelpers.USERNAME, "a #hash tag", testHelpers.getHashTagsFromMessage, function (result) {
-			testHelpers.validateOkResult(result);
-			should.exists(result.data.hashtags);
-			result.data.hashtags.should.not.be.emtpy;
-			result.data.hashtags[0].should.equal("#hash");
-			done();
-		});
-	});
-	it("creates an array with 2 hashtag for 2 hashtag in the message", function (done) {
-		dbAccess.addPost(testHelpers.USERNAME, "and now #two #hash tags", testHelpers.getHashTagsFromMessage, function (result) {
-			testHelpers.validateOkResult(result);
-			should.exists(result.data.hashtags);
-			result.data.hashtags.should.not.be.emtpy;
-			result.data.hashtags[0].should.equal("#two");
-			result.data.hashtags[1].should.equal("#hash");
-			done();
-		});
-	});
+  it("adds a correctly formatted new message", function (done) {
+    dbAccess
+      .addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+        testHelpers.validateOkResult(result);
+        should.exists(result.data._id);
+        result.data.username.should.be.equal(testHelpers.USERNAME);
+        result.data.message.should.be.equal(testHelpers.MESSAGE);
+        done();
+      });
+  });
+  it("calls my callback function with the error when an error occurs", function (done) {
+    dbAccess.addPost("", "", testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+      testHelpers.validateErrorResult(result, "");
+      done();
+    });
+  });
+  it("validates the prescense of an user name", function (done) {
+    dbAccess.addPost("", testHelpers.MESSAGE, testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+      testHelpers.validateErrorResult(result, "Username");
+      done();
+    });
+  });
+  it("validates the prescense of a message", function (done) {
+    dbAccess.addPost(testHelpers.USERNAME, "", testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+      testHelpers.validateErrorResult(result, "Message");
+      done();
+    });
+  });
+  it("adds the posted date", function (done) {
+    dbAccess.addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+      testHelpers.validateOkResult(result);
+      should.exists(result.data.time);
+      done();
+    });
+  });
+  it("creates the post with no replies", function (done) {
+    dbAccess.addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+      testHelpers.validateOkResult(result);
+      result.data.replies.should.be.emtpy;
+      done();
+    });
+  });
+  it("creates an empty hashtag list for no hashtags", function (done) {
+    dbAccess.addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+      testHelpers.validateOkResult(result);
+      result.data.hashtags.should.be.emtpy;
+      done();
+    });
+  });
+  it("creates an array with 1 hashtag for 1 hashtag in the message", function (done) {
+    dbAccess.addPost(testHelpers.USERNAME, "a #hash tag", testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+      testHelpers.validateOkResult(result);
+      should.exists(result.data.hashtags);
+      result.data.hashtags.should.not.be.emtpy;
+      result.data.hashtags[0].should.equal("#hash");
+      done();
+    });
+  });
+  it("creates an array with 2 hashtag for 2 hashtag in the message", function (done) {
+    dbAccess.addPost(testHelpers.USERNAME, "and now #two #hash tags", testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+      testHelpers.validateOkResult(result);
+      should.exists(result.data.hashtags);
+      result.data.hashtags.should.not.be.emtpy;
+      result.data.hashtags[0].should.equal("#two");
+      result.data.hashtags[1].should.equal("#hash");
+      done();
+    });
+  });
 });

--- a/test/dbAccess/addReply.spec.js
+++ b/test/dbAccess/addReply.spec.js
@@ -5,75 +5,66 @@ var testHelpers = require("./testHelpers.js");
 
 describe("Replying to posts", function () {
 
-	before(function (done) {
-		testHelpers.connectMongo();
-		done();
-	});
+  before(function (done) {
+    testHelpers.connectMongo();
+    done();
+  });
 
-	beforeEach(function (done) {
-		testHelpers.deleteAll();
-		done();
-	});
+  beforeEach(function (done) {
+    testHelpers.deleteAll();
+    done();
+  });
 
-	after(function (done) {
-		testHelpers.deleteAll();
-		done();
-	});
+  after(function (done) {
+    testHelpers.deleteAll();
+    done();
+  });
 
-	function validateNumberOfReplies(id, expectedNumberOfReplies) {
-		dbAccess.getPostById(id, function (result) {
-			testHelpers.validateOkResult(result);
-			result.data.replies.length.should.equal(expectedNumberOfReplies);
-		});
-	}
+  function validateNumberOfReplies(id, expectedNumberOfReplies) {
+    dbAccess.getPostById(id, function (result) {
+      testHelpers.validateOkResult(result);
+      result.data.replies.length.should.equal(expectedNumberOfReplies);
+    });
+  }
 
-	function validateNumberOfHashtagsOfReply(id, expectedNumberOfHashtags) {
-		dbAccess.getPostById(id, function (result) {
-			testHelpers.validateOkResult(result);
-			result.data.replies.length.should.equal(1);
-			result.data.replies[0].hashtags.length.should.equal(expectedNumberOfReplies);
-		});
-	}
-
-
-	it("adds a simple reply to a post", function (done) {
-		testHelpers.addTestPost(testHelpers.USERNAME, testHelpers.MESSAGE, function (result) {
-			var id = result.data._id;
-			dbAccess.addReply(id, "Hugo", "Tjääääna du'ra!", function (result) {
-				testHelpers.validateOkResult(result);
-				validateNumberOfReplies(id, 1);
-				done();
-			});
-		});
-	});
-	it("adds several replies to a post", function (done) {
-		testHelpers.addTestPost(testHelpers.USERNAME, testHelpers.MESSAGE, function (result) {
-			var id = result.data._id;
-			dbAccess.addReply(id, "Hugo", "Tjääääna du'ra!", function (result) {
-				dbAccess.addReply(id, "Per", "Tjääääna du'ra!", function (result) {
-					testHelpers.validateOkResult(result);
-					validateNumberOfReplies(id, 2);
-					done();
-				});
-			});
-		});
-	});
-	it("validates the presence of username", function (done) {
-		testHelpers.addTestPost(testHelpers.USERNAME, testHelpers.MESSAGE, function (result) {
-			var id = result.data._id;
-			dbAccess.addReply(id, "", "Tjääääna du'ra!", function (result) {
-				testHelpers.validateErrorResult(result, "Username");
-				done();
-			});
-		});
-	});
-	it("validates the presence of a message", function (done) {
-		testHelpers.addTestPost(testHelpers.USERNAME, testHelpers.MESSAGE, function (result) {
-			var id = result.data._id;
-			dbAccess.addReply(id, "Hugo", "", function (result) {
-				testHelpers.validateErrorResult(result, "Message");
-				done();
-			});
-		});
-	});
+  it("adds a simple reply to a post", function (done) {
+    testHelpers.addTestPost(testHelpers.USERNAME, testHelpers.MESSAGE, function (result) {
+      var id = result.data._id;
+      dbAccess.addReply(id, "Hugo", "Tjääääna du'ra!", testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+        testHelpers.validateOkResult(result);
+        validateNumberOfReplies(id, 1);
+        done();
+      });
+    });
+  });
+  it("adds several replies to a post", function (done) {
+    testHelpers.addTestPost(testHelpers.USERNAME, testHelpers.MESSAGE, function (result) {
+      var id = result.data._id;
+      dbAccess.addReply(id, "Hugo", "Tjääääna du'ra!", testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+        dbAccess.addReply(id, "Per", "Tjääääna du'ra!", testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+          testHelpers.validateOkResult(result);
+          validateNumberOfReplies(id, 2);
+          done();
+        });
+      });
+    });
+  });
+  it("validates the presence of username", function (done) {
+    testHelpers.addTestPost(testHelpers.USERNAME, testHelpers.MESSAGE, function (result) {
+      var id = result.data._id;
+      dbAccess.addReply(id, "", "Tjääääna du'ra!", testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+        testHelpers.validateErrorResult(result, "Username");
+        done();
+      });
+    });
+  });
+  it("validates the presence of a message", function (done) {
+    testHelpers.addTestPost(testHelpers.USERNAME, testHelpers.MESSAGE, function (result) {
+      var id = result.data._id;
+      dbAccess.addReply(id, "Hugo", "", testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
+        testHelpers.validateErrorResult(result, "Message");
+        done();
+      });
+    });
+  });
 });

--- a/test/dbAccess/getPost.spec.js
+++ b/test/dbAccess/getPost.spec.js
@@ -17,7 +17,7 @@ describe("Getting posts", function () {
 		});
 
 		it("gets a post by id", function (done) {
-			dbAccess.addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.getHashTagsFromMessage, function (result) {
+			dbAccess.addPost(testHelpers.USERNAME, testHelpers.MESSAGE, testHelpers.fakeXssIt, testHelpers.getHashTagsFromMessage, function (result) {
 				var id = result.data._id;
 
 				var postFromDb = dbAccess.getPostById(id, function (result) {

--- a/test/dbAccess/testHelpers.js
+++ b/test/dbAccess/testHelpers.js
@@ -1,6 +1,7 @@
 var mongoose = require("mongoose");
 var should = require("should");
 var dbAccess = require("../../lib/dbAccess/dbAccess");
+var xss = require("../../lib/xss.js");
 var model = require("../../lib/dbAccess/model.js");
 var config = require("../../config")("test");
 var Hashtag = model.Hashtag;
@@ -14,61 +15,74 @@ module.exports.USERNAME = USERNAME;
 module.exports.MESSAGE = MESSAGE;
 
 module.exports.connectMongo = function () {
-	dbAccess.connectToDb(config.mongoUrl);
+  dbAccess.connectToDb(config.mongoUrl);
 };
 
 module.exports.validateErrorResult = function (result, errorMessage) {
-	should.exists(result);
-	should.exists(result.success);
-	result.success.should.equal(false);
-	should.exists(result.errorMessage);
-	result.errorMessage.should.startWith(errorMessage);
-	should.not.exists(result.data);
+  should.exists(result);
+  should.exists(result.success);
+  result.success.should.equal(false);
+  should.exists(result.errorMessage);
+  result.errorMessage.should.startWith(errorMessage);
+  should.not.exists(result.data);
 };
 
 var validateOkResult = function (result) {
-	should.exists(result);
-	should.exists(result.success);
-	result.success.should.equal(true);
-	should.exists(result.errorMessage);
-	result.errorMessage.should.be.empty;
-	should.exists(result.data);
+  should.exists(result);
+  should.exists(result.success);
+  result.success.should.equal(true);
+  should.exists(result.errorMessage);
+  result.errorMessage.should.be.empty;
+  should.exists(result.data);
 };
+
 module.exports.validateOkResult = validateOkResult;
 
+var fakeXssIt = function (message) {
+  return message;
+};
+
+module.exports.fakeXssIt = fakeXssIt;
+
+var getHashTagsFromMessage = function (message) {
+  var hashs = [];
+  var i = 0;
+  var words = message.split(" ");
+  for (i = 0; i < words.length; i++) {
+    if (words[i][0] === "#") {
+      hashs.push(words[i]);
+    }
+  }
+
+  return hashs;
+};
+module.exports.getHashTagsFromMessage = getHashTagsFromMessage;
+
 module.exports.deleteAll = function () {
-	Post.remove({}, function (err) {
-		if(err) console.log(err);
-	});
-	Reply.remove({}, function (err) {
-		if(err) console.log(err);
-	});
+  Post.remove({}, function (err) {
+    if (err) {
+      console.log(err);
+    }
+  });
+  Reply.remove({}, function (err) {
+    if (err) {
+      console.log(err);
+    }
+  });
 };
 
 var addTestPost = function (username, message, cb) {
-	dbAccess.addPost(username, message, getHashTagsFromMessage, function (result) {
-		validateOkResult(result);
-		cb(result);
-	});
+  dbAccess.addPost(username, message, fakeXssIt, getHashTagsFromMessage, function (result) {
+    validateOkResult(result);
+    cb(result);
+  });
 };
+
 module.exports.addTestPost = addTestPost;
 
 module.exports.addTestPosts = function (numberOfPosts, callback) {
-	for (var i = 0; i <= numberOfPosts; i++) {
-		addTestPost(USERNAME, MESSAGE + " " + (i + 1), callback);
-	}
+  var i = 0;
+  for (i = 0; i <= numberOfPosts; i++) {
+    addTestPost(USERNAME, MESSAGE + " " + (i + 1), callback);
+  }
 };
-
-var getHashTagsFromMessage = function (message) {
-	var hashs = [];
-
-	var words = message.split(" ");
-	for (var i = 0; i < words.length; i++) {
-		if(words[i][0] === "#"){
-			hashs.push(words[i]);
-		}
-	}
-
-	return hashs;
-};
-module.exports.getHashTagsFromMessage = getHashTagsFromMessage;

--- a/test/hashTagsInMessage_spec.js
+++ b/test/hashTagsInMessage_spec.js
@@ -5,8 +5,8 @@ var testHelpers = require("./dbAccess/testHelpers.js");
 
 describe('Hashtags in posts or replies', function () {
   before(function (done) {
-      testHelpers.connectMongo();
-      done();
+    testHelpers.connectMongo();
+    done();
   });
 
   after(function (done) {
@@ -19,6 +19,15 @@ describe('Hashtags in posts or replies', function () {
       var hashtag = 'this #aptitalk is the best';
       var message = hashTagParser.toStaticHTML(hashtag);
       message.should.equal('this<a href=\"/hashtags/aptitalk\" target=\"_blank\"> #aptitalk</a> is the best');
+      done();
+    });
+  });
+
+  describe('When a user posts a message starting with a hashtag', function () {
+    it('the hashtag should be clickable in message', function (done) {
+      var hashtag = '#aptitålk is the best';
+      var message = hashTagParser.toStaticHTML(hashtag);
+      message.should.equal('<a href=\"/hashtags/aptitålk\" target=\"_blank\">#aptitålk</a> is the best');
       done();
     });
   });
@@ -77,8 +86,8 @@ describe('Hashtags in posts or replies', function () {
       chat.createPost('hugo', 'I think #aptitalk rocks', function (post) {
         chat.createPost('marcus', 'I think #aptitalk rocks indeeed', function (post) {
           chat.getPostsForHashtag('aptitalk', function (hashtag) {
-              hashtag.posts.length.should.be.equal(2);
-              done();
+            hashtag.posts.length.should.be.equal(2);
+            done();
           });
         });
       });

--- a/test/linksInMessage_spec.js
+++ b/test/linksInMessage_spec.js
@@ -1,5 +1,5 @@
 var should = require('should');
-var linkParser = require('../lib/linkParser.js');
+var linkParser = require('../lib/linkparser.js');
 
 describe('Links in posts or replies', function () {
   describe('When a user posts a message containing a link', function () {
@@ -10,7 +10,7 @@ describe('Links in posts or replies', function () {
       done();
     });
   });
-  
+
   describe('When a user posts a message containing multiple links', function () {
     it('the links should all be clickable in message', function (done) {
       var link = 'http://www.aptitud.se';
@@ -21,12 +21,12 @@ describe('Links in posts or replies', function () {
       done();
     });
   });
-  
+
   describe('When a user posts a message containing a link to an image', function () {
     it('the image should show up in the message', function (done) {
       var link = 'http://aptitud.se/images/aptitudlogo.png';
       var message = linkParser.toStaticHTML(link);
-      message.should.equal('<a href=\"' + link + '\" target=\"_blank\"><img class=\"img-message\" src=\"' + link +'\"></a>');
+      message.should.equal('<a href=\"' + link + '\" target=\"_blank\"><img class=\"img-message\" src=\"' + link + '\"></a>');
       done();
     });
   });
@@ -36,7 +36,7 @@ describe('Links in posts or replies', function () {
       var link = 'http://a.gifb.in/1047444azmp81le1x.gif';
       var link2 = 'http://a.gifb.in/082009/1251191958_naked_gun_leslie_nielsen.gif';
       var message = linkParser.toStaticHTML(link + ' ' + link2);
-      message.should.equal('<a href=\"' + link + '\" target=\"_blank\"><img class=\"img-message\" src=\"' + link +'\"></a> <a href=\"' + link2 + '\" target=\"_blank\"><img class=\"img-message\" src=\"' + link2 +'\"></a>');
+      message.should.equal('<a href=\"' + link + '\" target=\"_blank\"><img class=\"img-message\" src=\"' + link + '\"></a> <a href=\"' + link2 + '\" target=\"_blank\"><img class=\"img-message\" src=\"' + link2 + '\"></a>');
       done();
     });
   });
@@ -47,7 +47,7 @@ describe('Links in posts or replies', function () {
       var link2 = 'http://a.gifb.in/1047444azmp81le1x.gif';
       var complete = 'this is a link:' + link + ' and this is a image:' + link2 + ' and text after should be intact too.';
       var message = linkParser.toStaticHTML(complete);
-      message.should.equal('this is a link:<a href="' + link + '" target=\"_blank\">' + link + '</a> and this is a image:<a href=\"' + link2 + '\" target=\"_blank\"><img class=\"img-message\" src=\"' + link2 +'\"></a> and text after should be intact too.');
+      message.should.equal('this is a link:<a href="' + link + '" target=\"_blank\">' + link + '</a> and this is a image:<a href=\"' + link2 + '\" target=\"_blank\"><img class=\"img-message\" src=\"' + link2 + '\"></a> and text after should be intact too.');
       done();
     });
   });

--- a/test/postsAndReplies.spec.js
+++ b/test/postsAndReplies.spec.js
@@ -2,7 +2,6 @@ var should = require('should');
 var chat = require('../lib/chat.js');
 var testHelpers = require("./dbAccess/testHelpers.js");
 
-
 describe('Posts and replies', function () {
   before(function (done) {
     testHelpers.connectMongo();


### PR DESCRIPTION
The Hashtag parser was designed to be used on the raw message from users, but before this refactor we're using the hashtagparser on the message that already had been html parsed.
